### PR TITLE
Update go-version-action to latest version and fix bump type

### DIFF
--- a/.github/workflows/go-ci-cd.yml
+++ b/.github/workflows/go-ci-cd.yml
@@ -55,10 +55,10 @@ jobs:
 
       - name: Get and Bump version
         id: go_version
-        uses: dsaltares/go-version-action@v1.0.0
+        uses: phish1/go-version-action@v1
         with:
           version-file: 'VERSION'
-          bump: 'patch'
+          type: 'patch'
 
       - name: Create Git Tag
         run: |


### PR DESCRIPTION
Upgrade the `go-version-action` to the latest version and correct the bump type parameter for versioning.