### PR TITLE
Auto-increment version and create Git tag in CI/CD workflow

### DIFF
--- a/.github/workflows/go-ci-cd.yml
+++ b/.github/workflows/go-ci-cd.yml
@@ -53,19 +53,43 @@ jobs:
         with:
           go-version: '1.24'
 
-      - name: Get and Bump version
-        id: go_version
-        uses: phish1/go-version-action@v1
-        with:
-          version-file: 'VERSION'
-          type: 'patch'
-
-      - name: Create Git Tag
+      - name: Auto-increment Version and Create Tag
+        id: versioning
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git tag ${{ steps.go_version.outputs.version }}
-          git push origin ${{ steps.go_version.outputs.version }}
+          # Read current version from VERSION file
+          CURRENT_VERSION=$(cat VERSION)
+          echo "Current version: $CURRENT_VERSION"
+
+          # Extract major, minor, patch components
+          MAJOR=$(echo $CURRENT_VERSION | awk -F'.' '{print $1}')
+          MINOR=$(echo $CURRENT_VERSION | awk -F'.' '{print $2}')
+          PATCH=$(echo $CURRENT_VERSION | awk -F'.' '{print $3}')
+
+          # Increment patch version
+          NEW_PATCH=$((PATCH + 1))
+          NEW_VERSION="$MAJOR.$MINOR.$NEW_PATCH"
+          echo "New version: $NEW_VERSION"
+
+          # Write new version back to VERSION file
+          echo $NEW_VERSION > VERSION
+
+          # Configure Git user for the commit
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Add and commit the updated VERSION file
+          git add VERSION
+          git commit -m "Release: Bump version to $NEW_VERSION"
+
+          # Create Git tag
+          git tag $NEW_VERSION
+
+          # Push the updated VERSION file and the new tag
+          git push origin main
+          git push origin $NEW_VERSION
+
+          # Set the new versions as a step output for other steps to use
+          echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
         uses: docker/login-action@v3
@@ -82,13 +106,13 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ github.repository }}:latest
-            ghcr.io/${{ github.repository }}:${{ steps.go_version.outputs.version }}
+            ghcr.io/${{ github.repository }}:${{ steps.go_version.outputs.NEW_VERSION }}
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.go_version.outputs.version }}
-          name: Release ${{ steps.go_version.outputs.version }}
-          body: "Automated release for version ${{ steps.go_version.outputs.version }}"
+          tag_name: ${{ steps.go_version.outputs.NEW_VERSION }}
+          name: Release ${{ steps.go_version.outputs.NEW_VERSION }}
+          body: "Automated release for version ${{ steps.go_version.outputs.NEW_VERSION }}"
           draft: false
           prerelease: false


### PR DESCRIPTION
Implement a CI/CD workflow that automatically increments the version number and creates a Git tag upon release. This change enhances version management by automating the version bumping process and ensures that the new version is tagged and pushed to the repository.